### PR TITLE
Cleanup all language files

### DIFF
--- a/src/Lang/en_US/config.yml
+++ b/src/Lang/en_US/config.yml
@@ -1,8 +1,8 @@
-#This is the default config in English
-#Replace the original "config.yml" to use!
+# This is the default config in English
+# Replace the original "config.yml" to use!
 
 Database:
-  #Player data storage type, MYSQL or SQLITE
+  # Player data storage type, MYSQL or SQLITE
   Type: SQLITE
   MYSQL:
     Host: localhost
@@ -22,7 +22,7 @@ Messages:
     ToggleOff: "&eToggled %s off"
     PlayerNotFound: "&cThe player is not online!"
 
-#Enable InteractionVisualizer for these blocks
+# Enable InteractionVisualizer for these blocks
 Blocks:
   Anvil:
     Enabled: true
@@ -58,13 +58,13 @@ Blocks:
     Enabled: true
 
 Entities:
-  Villager: 
+  Villager:
     Enabled: true
 
-#Enable these modules for InteractionVisualizer displays
-#ItemStand represents all displays using armorstands and itemframes
-#ItemDrop represents all displays using dropped items
-#Hologram represents all holograpgic displays using armorstands
+# Enable these modules for InteractionVisualizer displays
+# ItemStand represents all displays using armorstands and itemframes
+# ItemDrop represents all displays using dropped items
+# Hologram represents all holograpgic displays using armorstands
 Modules:
   ItemStand:
     Enabled: true
@@ -75,4 +75,3 @@ Modules:
 
 Options:
   Updater: true
-  

--- a/src/Lang/en_US/effect.yml
+++ b/src/Lang/en_US/effect.yml
@@ -1,5 +1,5 @@
-#This is the default effect.yml in English
-#Replace the original "effect.yml" to use!
+# This is the default effect.yml in English
+# Replace the original "effect.yml" to use!
 
 Effects:
   ABSORPTION: Absorption

--- a/src/Lang/en_US/enchantment.yml
+++ b/src/Lang/en_US/enchantment.yml
@@ -1,5 +1,5 @@
-#This is the default enchantment.yml in English
-#Replace the original "enchantment.yml" to use!
+# This is the default enchantment.yml in English
+# Replace the original "enchantment.yml" to use!
 
 Enchantments:
     PROTECTION_FIRE: Fire Protection

--- a/src/Lang/es_ES/config.yml
+++ b/src/Lang/es_ES/config.yml
@@ -1,10 +1,10 @@
-#Spanish Language default config translated by Itaquito
-#https://www.spigotmc.org/members/itaquito.138085/
-#Replace the original "config.yml" to use!
+# Spanish Language default config translated by Itaquito
+# https://www.spigotmc.org/members/itaquito.138085/
+# Replace the original "config.yml" to use!
 
 Database:
-#Player data storage type, MYSQL or SQLITE
-#Información de jugadores almacenada en MYSQL o SQLITE
+# Player data storage type, MYSQL or SQLITE
+# Información de jugadores almacenada en MYSQL o SQLITE
   Type: SQLITE
   MYSQL:
     Host: localhost
@@ -24,8 +24,8 @@ Messages:
     ToggleOff: "&e%s se deshabilitó"
     PlayerNotFound: "&c¡El jugador no esta en línea!"
 
-#Enable InteractionVisualizer for these blocks
-#Habilita InteractionVisualizer para estos bloques
+# Enable InteractionVisualizer for these blocks
+# Habilita InteractionVisualizer para estos bloques
 Blocks:
   Anvil:
     Enabled: true
@@ -61,20 +61,20 @@ Blocks:
     Enabled: true
 
 Entities:
-  Villager: 
+  Villager:
     Enabled: true
 
-#Enable these modules for InteractionVisualizer displays
-#ItemStand represents all displays using armorstands and itemframes
-#ItemDrop represents all displays using dropped items
-#Hologram represents all holograpgic displays using armorstands
-#Habilita estos módulos para los displays de InteractionVisualizer
-#ItemStand representa todos los displays que usan armorstands y itemframes
-#ItemDrop representa todos los displays usando items en el suelo
-#Hologram representa todolos los display holográficos usando armorstands
+# Habilita estos módulos para los displays de InteractionVisualizer
+# ItemStand representa todos los displays que usan armorstands y itemframes
+# ItemDrop representa todos los displays usando items en el suelo
+# Hologram representa todolos los display holográficos usando armorstands
 Modules:
   ItemStand:
     Enabled: true
   ItemDrop:
     Enabled: true
   Hologram:
+    Enabled: true
+
+Options:
+  Updater: true

--- a/src/Lang/fr_FR/enchantment.yml
+++ b/src/Lang/fr_FR/enchantment.yml
@@ -1,6 +1,6 @@
-#French Language default enchantment.yml translated by Cry_Legende
-#https://www.spigotmc.org/members/cry_legende.288109/
-#Replace the original "enchantment.yml" to use!
+# French Language default enchantment.yml translated by Cry_Legende
+# https://www.spigotmc.org/members/cry_legende.288109/
+# Replace the original "enchantment.yml" to use!
 
 Enchantments:
     PROTECTION_FIRE: Protection contre le feu

--- a/src/Lang/ru_RU/config.yml
+++ b/src/Lang/ru_RU/config.yml
@@ -1,9 +1,9 @@
-#This is the default config in Russian by imDaniX
-#https://www.spigotmc.org/members/imdanix.99979/
-#Replace the original "config.yml" to use!
+# This is the default config in Russian by imDaniX
+# https://www.spigotmc.org/members/imdanix.99979/
+# Replace the original "config.yml" to use!
 
 Database:
-  #Тип хранилища данных игроков, MYSQL или SQLITE
+  # Тип хранилища данных игроков, MYSQL или SQLITE
   Type: SQLITE
   MYSQL:
     Host: localhost
@@ -23,7 +23,7 @@ Messages:
     ToggleOff: "&eОтключено у %s"
     PlayerNotFound: "&cЭтот игрок не онлайн!"
 
-#Включение InteractionVisualizer для следующих блоков
+# Включение InteractionVisualizer для следующих блоков
 Blocks:
   Anvil:
     Enabled: true
@@ -59,13 +59,13 @@ Blocks:
     Enabled: true
 
 Entities:
-  Villager: 
+  Villager:
     Enabled: true
 
-#Включите эти модули для отображения InteractionVisualizer
-#ItemStand отвечает за отображения с использованием стоек для брони и рамок
-#ItemDrop отвечает за отображения с использованием выброшенных предметов
-#Hologram отвечает за голограммы с использованием стоек для брони
+# Включите эти модули для отображения InteractionVisualizer
+# ItemStand отвечает за отображения с использованием стоек для брони и рамок
+# ItemDrop отвечает за отображения с использованием выброшенных предметов
+# Hologram отвечает за голограммы с использованием стоек для брони
 Modules:
   ItemStand:
     Enabled: true
@@ -76,4 +76,3 @@ Modules:
 
 Options:
   Updater: true
-  

--- a/src/Lang/ru_RU/effect.yml
+++ b/src/Lang/ru_RU/effect.yml
@@ -1,6 +1,6 @@
-#This is the default effect.yml in Russian by imDaniX
-#https://www.spigotmc.org/members/imdanix.99979/
-#Replace the original "effect.yml" to use!
+# This is the default effect.yml in Russian by imDaniX
+# https://www.spigotmc.org/members/imdanix.99979/
+# Replace the original "effect.yml" to use!
 
 Effects:
   ABSORPTION: Поглощение

--- a/src/Lang/ru_RU/enchantment.yml
+++ b/src/Lang/ru_RU/enchantment.yml
@@ -1,6 +1,6 @@
-#This is the default enchantment.yml in Russian by imDaniX
-#https://www.spigotmc.org/members/imdanix.99979/
-#Replace the original "enchantment.yml" to use!
+# This is the default enchantment.yml in Russian by imDaniX
+# https://www.spigotmc.org/members/imdanix.99979/
+# Replace the original "enchantment.yml" to use!
 
 Enchantments:
     PROTECTION_FIRE: Огнеупорность

--- a/src/Lang/zh_CN/config.yml
+++ b/src/Lang/zh_CN/config.yml
@@ -1,9 +1,9 @@
-#Chinese (Simplified) Language default config translated by StarYunmeng
-#https://www.spigotmc.org/members/staryunmeng.589461/
-#Replace the original "config.yml" to use!
+# Chinese (Simplified) Language default config translated by StarYunmeng
+# https://www.spigotmc.org/members/staryunmeng.589461/
+# Replace the original "config.yml" to use!
 
 Database:
-  #数据库储存类型 MYSQL 或 SQLITE
+  # 数据库储存类型 MYSQL 或 SQLITE
   Type: SQLITE
   MYSQL:
     Host: localhost
@@ -21,7 +21,8 @@ Messages:
     ToggleOn: "&a切换 %s 开启"
     ToggleOff: "&e切换 %s 关闭"
     PlayerNotFound: "&c玩家不在线"
-#方块动画启动设置设置成false便可以关闭动画
+
+# 方块动画启动设置设置成false便可以关闭动画
 Blocks:
   Anvil:
     Enabled: true
@@ -57,13 +58,13 @@ Blocks:
     Enabled: true
 
 Entities:
-  Villager: 
+  Villager:
     Enabled: true
 
-#Enable these modules for InteractionVisualizer displays
-#ItemStand represents all displays using armorstands and itemframes
-#ItemDrop represents all displays using dropped items
-#Hologram represents all holograpgic displays using armorstands
+# Enable these modules for InteractionVisualizer displays
+# ItemStand represents all displays using armorstands and itemframes
+# ItemDrop represents all displays using dropped items
+# Hologram represents all holograpgic displays using armorstands
 Modules:
   ItemStand:
     Enabled: true
@@ -72,6 +73,6 @@ Modules:
   Hologram:
     Enabled: true
 
-#中国网络限制更新功能建议关闭
+# 中国网络限制更新功能建议关闭
 Options:
-  Updater: false
+  Updater: true

--- a/src/Lang/zh_CN/effect.yml
+++ b/src/Lang/zh_CN/effect.yml
@@ -1,6 +1,6 @@
-#Chinese (Simplified) Language default effect.yml translated by BackWheel
-#https://github.com/BackWheel
-#Replace the original "effect.yml" to use!
+# Chinese (Simplified) Language default effect.yml translated by BackWheel
+# https://github.com/BackWheel
+# Replace the original "effect.yml" to use!
 
 Effects:
   ABSORPTION: 伤害吸收

--- a/src/Lang/zh_CN/enchantment.yml
+++ b/src/Lang/zh_CN/enchantment.yml
@@ -1,6 +1,6 @@
-#Chinese (Simplified) Language default enchantment.yml translated by BackWheel
-#https://github.com/BackWheel
-#Replace the original "enchantment.yml" to use!
+# Chinese (Simplified) Language default enchantment.yml translated by BackWheel
+# https://github.com/BackWheel
+# Replace the original "enchantment.yml" to use!
 
 Enchantments:
   PROTECTION_FIRE: 火焰保护

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,5 +1,5 @@
 Database:
-  #Player data storage type, MYSQL or SQLITE
+  # Player data storage type, MYSQL or SQLITE
   Type: SQLITE
   MYSQL:
     Host: localhost
@@ -19,7 +19,7 @@ Messages:
     ToggleOff: "&eToggled %s off"
     PlayerNotFound: "&cThe player is not online!"
 
-#Enable InteractionVisualizer for these blocks
+# Enable InteractionVisualizer for these blocks
 Blocks:
   Anvil:
     Enabled: true
@@ -55,13 +55,13 @@ Blocks:
     Enabled: true
 
 Entities:
-  Villager: 
+  Villager:
     Enabled: true
 
-#Enable these modules for InteractionVisualizer displays
-#ItemStand represents all displays using armorstands and itemframes
-#ItemDrop represents all displays using dropped items
-#Hologram represents all holograpgic displays using armorstands
+# Enable these modules for InteractionVisualizer displays
+# ItemStand represents all displays using armorstands and itemframes
+# ItemDrop represents all displays using dropped items
+# Hologram represents all holograpgic displays using armorstands
 Modules:
   ItemStand:
     Enabled: true
@@ -72,4 +72,3 @@ Modules:
 
 Options:
   Updater: true
-  


### PR DESCRIPTION
- add a missing newline at end of file
- remove trailing whitespaces
- add a whitespace after comment char
- synchronize default settings with all languages
- remove leftover English text from Spanish translation 
