### PR TITLE
Real equals impl to improve allocations

### DIFF
--- a/src/main/java/com/loohp/interactionvisualizer/objectholders/EntryKey.java
+++ b/src/main/java/com/loohp/interactionvisualizer/objectholders/EntryKey.java
@@ -1,5 +1,6 @@
 package com.loohp.interactionvisualizer.objectholders;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.bukkit.plugin.Plugin;
@@ -80,8 +81,12 @@ public class EntryKey {
 
 	@Override
 	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
 		if (obj instanceof EntryKey) {
-			return toString().equals(obj.toString());
+			EntryKey other = (EntryKey) obj;
+			return Objects.equals(other.namespace, this.namespace) && Objects.equals(other.key, this.key);
 		}
 		return false;
 	}


### PR DESCRIPTION
As checking player preferences is very common, the equals
method here generates a lot of garbage strings which
increases garbage collection time and frequency.


You can see this here, where 45% of the user's allocations on the entire server are caused by this equals call.
![image](https://user-images.githubusercontent.com/3516420/130261202-485b72e3-5068-4591-a865-ae3af372258b.png)
