### PR TITLE
Use ignoreCancelled instead of checking it manually

### DIFF
--- a/src/main/java/com/loohp/interactionvisualizer/blocks/AnvilDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/AnvilDisplay.java
@@ -183,12 +183,9 @@ public class AnvilDisplay extends VisualizerInteractDisplay implements Listener 
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onAnvil(InventoryClickEvent event) {
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         if (event.getRawSlot() != 2) {
@@ -311,11 +308,8 @@ public class AnvilDisplay extends VisualizerInteractDisplay implements Listener 
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseAnvil(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }
@@ -341,11 +335,8 @@ public class AnvilDisplay extends VisualizerInteractDisplay implements Listener 
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onDragAnvil(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/BarrelDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/BarrelDisplay.java
@@ -66,12 +66,9 @@ public class BarrelDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseBarrel(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished(player)) {
             return;
         }
@@ -236,12 +233,9 @@ public class BarrelDisplay implements Listener, VisualizerDisplay {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragBarrel(InventoryDragEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/BeeHiveDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/BeeHiveDisplay.java
@@ -173,30 +173,21 @@ public class BeeHiveDisplay extends VisualizerRunnableDisplay implements Listene
         }, 0, checkingPeriod).getTaskId();
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBeeEnterBeehive(EntityEnterBlockEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         Block block = event.getBlock();
         Bukkit.getScheduler().runTaskLater(InteractionVisualizer.plugin, () -> updateBlock(block), 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBeeLeaveBeehive(EntityChangeBlockEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         Block block = event.getBlock();
         Bukkit.getScheduler().runTaskLater(InteractionVisualizer.plugin, () -> updateBlock(block), 1);
     }
 
     @SuppressWarnings("deprecation")
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onInteractBeehive(PlayerInteractEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         Block block = event.getClickedBlock();
         if (block != null) {
             Bukkit.getScheduler().runTaskLater(InteractionVisualizer.plugin, () -> updateBlock(block), 1);

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/BeeNestDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/BeeNestDisplay.java
@@ -173,30 +173,21 @@ public class BeeNestDisplay extends VisualizerRunnableDisplay implements Listene
         }, 0, checkingPeriod).getTaskId();
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBeeEnterBeenest(EntityEnterBlockEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         Block block = event.getBlock();
         Bukkit.getScheduler().runTaskLater(InteractionVisualizer.plugin, () -> updateBlock(block), 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBeeLeaveBeenest(EntityChangeBlockEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         Block block = event.getBlock();
         Bukkit.getScheduler().runTaskLater(InteractionVisualizer.plugin, () -> updateBlock(block), 1);
     }
 
     @SuppressWarnings("deprecation")
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onInteractBeenest(PlayerInteractEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         Block block = event.getClickedBlock();
         if (block != null) {
             Bukkit.getScheduler().runTaskLater(InteractionVisualizer.plugin, () -> updateBlock(block), 1);

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/BlastFurnaceDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/BlastFurnaceDisplay.java
@@ -292,12 +292,9 @@ public class BlastFurnaceDisplay extends VisualizerRunnableDisplay implements Li
         }, 0, checkingPeriod).getTaskId();
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlastFurnace(InventoryClickEvent event) {
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         if (event.getRawSlot() != 0 && event.getRawSlot() != 2) {
@@ -397,11 +394,8 @@ public class BlastFurnaceDisplay extends VisualizerRunnableDisplay implements Li
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseBlastFurnace(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }
@@ -427,11 +421,8 @@ public class BlastFurnaceDisplay extends VisualizerRunnableDisplay implements Li
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragBlastFurnace(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/BrewingStandDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/BrewingStandDisplay.java
@@ -270,11 +270,8 @@ public class BrewingStandDisplay extends VisualizerRunnableDisplay implements Li
         }, 0, checkingPeriod).getTaskId();
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseBrewingStand(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }
@@ -300,11 +297,8 @@ public class BrewingStandDisplay extends VisualizerRunnableDisplay implements Li
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragBrewingStand(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/CartographyTableDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/CartographyTableDisplay.java
@@ -196,11 +196,8 @@ public class CartographyTableDisplay extends VisualizerInteractDisplay implement
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseCartographyTable(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (!playermap.containsKey((Player) event.getWhoClicked())) {
             return;
         }
@@ -210,11 +207,8 @@ public class CartographyTableDisplay extends VisualizerInteractDisplay implement
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragCartographyTable(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (!playermap.containsKey((Player) event.getWhoClicked())) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/ChestDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/ChestDisplay.java
@@ -69,12 +69,9 @@ public class ChestDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseChest(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished(player)) {
             return;
         }
@@ -245,12 +242,9 @@ public class ChestDisplay implements Listener, VisualizerDisplay {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragChest(InventoryDragEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/ConduitDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/ConduitDisplay.java
@@ -204,11 +204,8 @@ public class ConduitDisplay extends VisualizerRunnableDisplay implements Listene
         }, 0, checkingPeriod).getTaskId();
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlaceConduit(BlockPlaceEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         Block block = event.getBlockPlaced();
         if (conduitMap.containsKey(block)) {
             return;

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/CraftingTableDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/CraftingTableDisplay.java
@@ -308,11 +308,8 @@ public class CraftingTableDisplay extends VisualizerInteractDisplay implements L
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onCraft(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
             return;
         }
@@ -460,11 +457,8 @@ public class CraftingTableDisplay extends VisualizerInteractDisplay implements L
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseCraftingBench(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (!playermap.containsKey((Player) event.getWhoClicked())) {
             return;
         }
@@ -474,11 +468,8 @@ public class CraftingTableDisplay extends VisualizerInteractDisplay implements L
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragCraftingBench(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (!playermap.containsKey((Player) event.getWhoClicked())) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/DispenserDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/DispenserDisplay.java
@@ -65,12 +65,9 @@ public class DispenserDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseDispenser(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished(player)) {
             return;
         }
@@ -232,12 +229,9 @@ public class DispenserDisplay implements Listener, VisualizerDisplay {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragDispenser(InventoryDragEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/DoubleChestDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/DoubleChestDisplay.java
@@ -73,12 +73,9 @@ public class DoubleChestDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseDoubleChest(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished(player)) {
             return;
         }
@@ -267,12 +264,9 @@ public class DoubleChestDisplay implements Listener, VisualizerDisplay {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragDoubleChest(InventoryDragEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/DropperDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/DropperDisplay.java
@@ -66,12 +66,9 @@ public class DropperDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseDropper(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished(player)) {
             return;
         }
@@ -236,12 +233,9 @@ public class DropperDisplay implements Listener, VisualizerDisplay {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragDropper(InventoryDragEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/EnchantmentTableDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/EnchantmentTableDisplay.java
@@ -177,12 +177,9 @@ public class EnchantmentTableDisplay extends VisualizerInteractDisplay implement
         }, 2);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEnchant(EnchantItemEvent event) {
         if (VanishUtils.isVanished(event.getEnchanter())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         Block block = event.getEnchantBlock();
@@ -212,12 +209,9 @@ public class EnchantmentTableDisplay extends VisualizerInteractDisplay implement
         }, 2);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEnchantmentTableTake(InventoryClickEvent event) {
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         if (event.getRawSlot() != 0) {
@@ -269,12 +263,8 @@ public class EnchantmentTableDisplay extends VisualizerInteractDisplay implement
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseEnchantmentTable(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
-
         Player player = (Player) event.getWhoClicked();
 
         if (!playermap.containsKey(player)) {
@@ -286,12 +276,8 @@ public class EnchantmentTableDisplay extends VisualizerInteractDisplay implement
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragEnchantmentTable(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
-
         Player player = (Player) event.getWhoClicked();
 
         if (!playermap.containsKey(player)) {

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/EnderchestDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/EnderchestDisplay.java
@@ -70,11 +70,8 @@ public class EnderchestDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onOpenEnderChest(InventoryOpenEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished((Player) event.getPlayer())) {
             return;
         }
@@ -121,12 +118,9 @@ public class EnderchestDisplay implements Listener, VisualizerDisplay {
         playermap.put((Player) event.getPlayer(), block);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseEnderChest(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (!playermap.containsKey(player)) {
             return;
         }
@@ -263,12 +257,9 @@ public class EnderchestDisplay implements Listener, VisualizerDisplay {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragEnderChest(InventoryDragEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (!playermap.containsKey(player)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/FurnaceDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/FurnaceDisplay.java
@@ -294,12 +294,9 @@ public class FurnaceDisplay extends VisualizerRunnableDisplay implements Listene
         }, 0, checkingPeriod).getTaskId();
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onFurnace(InventoryClickEvent event) {
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         if (event.getRawSlot() != 0 && event.getRawSlot() != 2) {
@@ -399,11 +396,8 @@ public class FurnaceDisplay extends VisualizerRunnableDisplay implements Listene
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseFurnace(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }
@@ -429,11 +423,8 @@ public class FurnaceDisplay extends VisualizerRunnableDisplay implements Listene
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragFurnace(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/GrindstoneDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/GrindstoneDisplay.java
@@ -179,12 +179,9 @@ public class GrindstoneDisplay extends VisualizerInteractDisplay implements List
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onGrindstone(InventoryClickEvent event) {
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         if (event.getRawSlot() != 2) {
@@ -307,11 +304,8 @@ public class GrindstoneDisplay extends VisualizerInteractDisplay implements List
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseGrindstone(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }
@@ -337,11 +331,8 @@ public class GrindstoneDisplay extends VisualizerInteractDisplay implements List
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragGrindstone(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/HopperDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/HopperDisplay.java
@@ -66,12 +66,9 @@ public class HopperDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseHopper(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished(player)) {
             return;
         }
@@ -236,12 +233,9 @@ public class HopperDisplay implements Listener, VisualizerDisplay {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragHopper(InventoryDragEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/LoomDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/LoomDisplay.java
@@ -200,12 +200,9 @@ public class LoomDisplay extends VisualizerInteractDisplay implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onLoom(InventoryClickEvent event) {
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         if (event.getRawSlot() != 0 && event.getRawSlot() != 3) {
@@ -311,11 +308,8 @@ public class LoomDisplay extends VisualizerInteractDisplay implements Listener {
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseLoom(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }
@@ -341,11 +335,8 @@ public class LoomDisplay extends VisualizerInteractDisplay implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragLoom(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/ShulkerBoxDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/ShulkerBoxDisplay.java
@@ -67,12 +67,9 @@ public class ShulkerBoxDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseShulkerbox(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished(player)) {
             return;
         }
@@ -237,12 +234,9 @@ public class ShulkerBoxDisplay implements Listener, VisualizerDisplay {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragShulkerbox(InventoryDragEvent event) {
         Player player = (Player) event.getWhoClicked();
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/SmithingTableDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/SmithingTableDisplay.java
@@ -201,11 +201,8 @@ public class SmithingTableDisplay extends VisualizerInteractDisplay implements L
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onSmithingTable(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         int maxSlot = event.getView().getTopInventory().getSize() - 1;
         String maxSlotStr = String.valueOf(maxSlot);
         if (event.getRawSlot() != maxSlot) {
@@ -337,11 +334,8 @@ public class SmithingTableDisplay extends VisualizerInteractDisplay implements L
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseSmithingTable(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }
@@ -354,11 +348,8 @@ public class SmithingTableDisplay extends VisualizerInteractDisplay implements L
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onDragSmithingTable(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/SmokerDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/SmokerDisplay.java
@@ -292,12 +292,9 @@ public class SmokerDisplay extends VisualizerRunnableDisplay implements Listener
         }, 0, checkingPeriod).getTaskId();
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onSmoker(InventoryClickEvent event) {
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         if (event.getRawSlot() != 0 && event.getRawSlot() != 2) {
@@ -396,11 +393,8 @@ public class SmokerDisplay extends VisualizerRunnableDisplay implements Listener
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseSmoker(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }
@@ -426,11 +420,8 @@ public class SmokerDisplay extends VisualizerRunnableDisplay implements Listener
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragSmoker(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (event.getWhoClicked().getGameMode().equals(GameMode.SPECTATOR)) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/blocks/StonecutterDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/blocks/StonecutterDisplay.java
@@ -217,12 +217,9 @@ public class StonecutterDisplay extends VisualizerInteractDisplay implements Lis
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onStonecutter(InventoryClickEvent event) {
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
-            return;
-        }
-        if (event.isCancelled()) {
             return;
         }
         if (event.getRawSlot() != 1) {
@@ -309,11 +306,8 @@ public class StonecutterDisplay extends VisualizerInteractDisplay implements Lis
         }, 1);
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onUseStonecutter(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (!playermap.containsKey((Player) event.getWhoClicked())) {
             return;
         }
@@ -323,11 +317,8 @@ public class StonecutterDisplay extends VisualizerInteractDisplay implements Lis
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDragStonecutter(InventoryDragEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (!playermap.containsKey((Player) event.getWhoClicked())) {
             return;
         }

--- a/src/main/java/com/loohp/interactionvisualizer/entities/VillagerDisplay.java
+++ b/src/main/java/com/loohp/interactionvisualizer/entities/VillagerDisplay.java
@@ -54,11 +54,8 @@ public class VillagerDisplay implements Listener, VisualizerDisplay {
         return KEY;
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onVillageTrade(InventoryClickEvent event) {
-        if (event.isCancelled()) {
-            return;
-        }
         if (VanishUtils.isVanished((Player) event.getWhoClicked())) {
             return;
         }


### PR DESCRIPTION
This moved all `event.isCancelled()` checks to `ignoreCancelled = true` values on the `@EventHandler` annotation. This not only makes the code cleaner but also slightly improves performance of all those listeners as this can now be directly checked by the PluginManager when choosing the Listeners to forward Events to instead of having to first call the lsitener method handle.